### PR TITLE
Add default empty object for query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,9 +42,10 @@ module.exports = feathersApp => {
         const {
           path,
           httpMethod: method,
-          queryStringParameters: query,
           body: bodyAsString
         } = event
+
+        const query = event.queryStringParameters || {}
 
         const body = bodyAsString
           ? JSON.parse(bodyAsString)


### PR DESCRIPTION
Error: `cannot read property $sort of null`

Many service builders expect the query object to be initialised with a empty object. For example, if you were to use this with feathers-knex. 