### PR TITLE
Use resource rather than path to find service

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ module.exports = feathersApp => {
         await self.setupPromise
 
         const {
-          path,
+          resource,
           httpMethod: method,
           queryStringParameters: query,
           body: bodyAsString
@@ -50,12 +50,12 @@ module.exports = feathersApp => {
           ? JSON.parse(bodyAsString)
           : {}
 
-        const { service: serviceName, feathersId } = getService(self, path)
+        const { service: serviceName, feathersId } = getService(self, resource)
 
         if (!serviceName || !self.service(serviceName)) {
           return cb(null, {
             statusCode: 404,
-            body: JSON.stringify({ error: `Service not found: ${path}` })
+            body: JSON.stringify({ error: `Service not found: ${resource}` })
           })
         }
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -17,7 +17,7 @@ test('integration test: happy path', async () => {
     })
     .handler()
 
-  await app({ path: 'hello', httpMethod: 'GET' }, null, cb)
+  await app({ resource: 'hello', httpMethod: 'GET' }, null, cb)
 
   expect(cb).toHaveBeenCalledWith(null, { body: JSON.stringify({ data: fooBar }) })
 })


### PR DESCRIPTION
The lambda context provides both `path` and `resource` params which matches up to the feathers service. However, the path may have additional namespacing if, for example, one uses a custom domain mappings.

One issue though.. `serverless-offline` has currently got these wrong/mixed up, so it will break for a lot of people's local dev - https://github.com/dherault/serverless-offline/issues/1029